### PR TITLE
Update ProcessFactory implementation in 1.x

### DIFF
--- a/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
+++ b/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
@@ -158,7 +158,8 @@ public class ProcessFactory : Abstractions.IProcessFactory
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
 #endif
-    public Process StartNew(ProcessStartInfo startInfo, Processes.Abstractions.UserCredential credential)
+    public Process StartNew(ProcessStartInfo startInfo,
+        Processes.Abstractions.UserCredential credential)
     {
         Process process = From(startInfo, credential);
         
@@ -184,7 +185,8 @@ public class ProcessFactory : Abstractions.IProcessFactory
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
 #endif
-    public Process StartNew(ProcessStartInfo startInfo, Processes.Abstractions.ProcessResourcePolicy resourcePolicy)
+    public Process StartNew(ProcessStartInfo startInfo,
+        Processes.Abstractions.ProcessResourcePolicy resourcePolicy)
     {
         Process process = From(startInfo);
 
@@ -213,7 +215,9 @@ public class ProcessFactory : Abstractions.IProcessFactory
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
 #endif
-    public Process StartNew(ProcessStartInfo startInfo, Processes.Abstractions.ProcessResourcePolicy resourcePolicy, Processes.Abstractions.UserCredential credential)
+    public Process StartNew(ProcessStartInfo startInfo, 
+        Processes.Abstractions.ProcessResourcePolicy resourcePolicy,
+        Processes.Abstractions.UserCredential credential)
     {
         Process process = From(startInfo, credential);
         

--- a/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
+++ b/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
@@ -352,7 +352,8 @@ public class ProcessFactory : Abstractions.IProcessFactory
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
 #endif
-    public async Task<Processes.Abstractions.BufferedProcessResult> ContinueWhenExitBufferedAsync(Process process, Processes.Abstractions.ProcessResultValidation resultValidation,
+    public async Task<Processes.Abstractions.BufferedProcessResult> ContinueWhenExitBufferedAsync(Process process,
+        Processes.Abstractions.ProcessResultValidation resultValidation,
         CancellationToken cancellationToken = default)
     {
         await process.WaitForExitAsync(cancellationToken);

--- a/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
+++ b/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
@@ -237,8 +237,9 @@ public class ProcessFactory : Abstractions.IProcessFactory
     {
         Process process = From(configuration);
 
-        if (process.StartInfo.RedirectStandardInput && configuration.StandardInput is not null)
+        if (configuration.StandardInput is not null)
         {
+            process.StartInfo.RedirectStandardInput = true;
             configuration.StandardInput.BaseStream.CopyTo(process.StandardInput.BaseStream);
         }
         

--- a/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
+++ b/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
@@ -236,6 +236,11 @@ public class ProcessFactory : Abstractions.IProcessFactory
     public Process StartNew(Processes.Abstractions.ProcessConfiguration configuration)
     {
         Process process = From(configuration);
+
+        if (process.StartInfo.RedirectStandardInput && configuration.StandardInput is not null)
+        {
+            configuration.StandardInput.BaseStream.CopyTo(process.StandardInput.BaseStream);
+        }
         
         process.Start();
         

--- a/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
+++ b/src/AlastairLundy.Extensions.Processes/ProcessFactory.cs
@@ -356,6 +356,9 @@ public class ProcessFactory : Abstractions.IProcessFactory
         Processes.Abstractions.ProcessResultValidation resultValidation,
         CancellationToken cancellationToken = default)
     {
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        
         await process.WaitForExitAsync(cancellationToken);
         
         if (process.ExitCode != 0 && resultValidation == Processes.Abstractions.ProcessResultValidation.ExitCodeZero)


### PR DESCRIPTION
This PR addresses the following with regards to ProcessFactory:

- Wrapped long lines
- Pipe Standard Input into new Processes created using the ``StartNew`` method when a ProcessConfiguration parameter is passed and the Standard Input to pass is not null
- Fixed a potential issue where the ``ContinueWhenExitBufferedAsync`` method would not redirect standard output and standard error.